### PR TITLE
Simplify linter logic

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -2,22 +2,17 @@ package analyzer
 
 import (
 	"go/ast"
-	"go/token"
-	"go/types"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
 const (
-	gomockControllerType = "github.com/golang/mock/gomock.Controller"
-	gomockPkg            = "github.com/golang/mock/gomock"
+	gomockControllerType = "mock/gomock.Controller"
 	finish               = "Finish"
-	newControllerMethod  = "NewController"
-	testingType          = "*testing.T"
+	reportMsg            = "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
 )
 
 // New returns new gomockcontrollerfinish analyzer.
@@ -34,9 +29,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	inspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	nodeFilter := []ast.Node{(*ast.CallExpr)(nil)}
 
-	// map to track whether NewController is called for each testing function
-	newControllerCalledMap := make(map[string]bool)
-
 	inspector.Preorder(nodeFilter, func(n ast.Node) {
 		callExpr, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -45,12 +37,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		// check if it's a test file
 		if !isTestFile(pass.Fset.Position(callExpr.Pos()).Filename) {
-			return
-		}
-
-		// Check if it's a testing function
-		funcDecl, ok := enclosingFunction(pass, callExpr.Pos())
-		if !ok {
 			return
 		}
 
@@ -64,24 +50,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return
 		}
 
-		// get pkg name if expression is from Go package
-		pkg, ok := pass.TypesInfo.ObjectOf(selIdent).(*types.PkgName)
-		// check if it's gomock pkg and method is NewController
-		if ok && strings.HasSuffix(pkg.Imported().Path(), gomockPkg) && selectorExpr.Sel.Name == newControllerMethod {
-			if len(callExpr.Args) == 1 {
-				if argType := pass.TypesInfo.TypeOf(callExpr.Args[0]); argType.String() == testingType {
-					// set newControllerCalled state for current testing function to true
-					newControllerCalledMap[funcDecl.Name.Name] = true
-				}
-			}
-		}
-
 		// check for unnecessary call to gomock.Controller.Finish()
 		if strings.HasSuffix(pass.TypesInfo.TypeOf(selIdent).String(), gomockControllerType) && selectorExpr.Sel.Name == finish {
-			// check if NewController is called for current testing function
-			if newControllerCalledMap[funcDecl.Name.Name] {
-				pass.Reportf(selectorExpr.Sel.Pos(), "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed")
-			}
+			pass.Reportf(selectorExpr.Sel.Pos(), reportMsg)
 		}
 	})
 
@@ -91,24 +62,4 @@ func run(pass *analysis.Pass) (interface{}, error) {
 // isTestFile checks if the file is a test file based on its name.
 func isTestFile(filename string) bool {
 	return strings.HasSuffix(filename, "_test.go")
-}
-
-// enclosingFunction returns the enclosing function declaration for a given position.
-func enclosingFunction(pass *analysis.Pass, pos token.Pos) (*ast.FuncDecl, bool) {
-	var file *ast.File
-
-	for _, f := range pass.Files {
-		if f.Pos() <= pos && pos <= f.End() {
-			file = f
-			break
-		}
-	}
-
-	path, _ := astutil.PathEnclosingInterval(file, pos, pos)
-	for _, node := range path {
-		if funcDecl, ok := node.(*ast.FuncDecl); ok {
-			return funcDecl, true
-		}
-	}
-	return nil, false
 }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -12,7 +12,7 @@ import (
 const (
 	gomockControllerType = "mock/gomock.Controller"
 	finish               = "Finish"
-	reportMsg            = "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	reportMsg            = "calling Finish on gomock.Controller is no longer needed"
 )
 
 // New returns new gomockcontrollerfinish analyzer.
@@ -52,7 +52,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		// check for unnecessary call to gomock.Controller.Finish()
 		if strings.HasSuffix(pass.TypesInfo.TypeOf(selIdent).String(), gomockControllerType) && selectorExpr.Sel.Name == finish {
-			pass.Reportf(selectorExpr.Sel.Pos(), reportMsg)
+			pass.Reportf(callExpr.Pos(), reportMsg)
 		}
 	})
 

--- a/pkg/analyzer/testdata/src/examples/original_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/original_pkg_test.go
@@ -16,10 +16,6 @@ func TestFinishCallDefer(t *testing.T) {
 	defer mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
 }
 
-func TestNoFinishCall(t *testing.T) {
-	gomock.NewController(t)
-}
-
 func TestFinishCallWithoutT(t *testing.T) {
 	mock := gomock.NewController(nil)
 	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
@@ -32,4 +28,13 @@ func TestFinsihCallInAnotherFunction(t *testing.T) {
 
 func callFinish(mock *gomock.Controller) {
 	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+}
+
+func TestNoFinishCall(t *testing.T) {
+	gomock.NewController(t)
+}
+
+func TestFinishCallOther(t *testing.T) {
+	mock := New()
+	mock.Finish()
 }

--- a/pkg/analyzer/testdata/src/examples/original_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/original_pkg_test.go
@@ -22,5 +22,14 @@ func TestNoFinishCall(t *testing.T) {
 
 func TestFinishCallWithoutT(t *testing.T) {
 	mock := gomock.NewController(nil)
-	mock.Finish()
+	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+}
+
+func TestFinsihCallInAnotherFunction(t *testing.T) {
+	mock := gomock.NewController(t)
+	callFinish(mock)
+}
+
+func callFinish(mock *gomock.Controller) {
+	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
 }

--- a/pkg/analyzer/testdata/src/examples/original_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/original_pkg_test.go
@@ -8,17 +8,17 @@ import (
 
 func TestFinishCall(t *testing.T) {
 	mock := gomock.NewController(t)
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestFinishCallDefer(t *testing.T) {
 	mock := gomock.NewController(t)
-	defer mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	defer mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestFinishCallWithoutT(t *testing.T) {
 	mock := gomock.NewController(nil)
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestFinsihCallInAnotherFunction(t *testing.T) {
@@ -27,7 +27,7 @@ func TestFinsihCallInAnotherFunction(t *testing.T) {
 }
 
 func callFinish(mock *gomock.Controller) {
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestNoFinishCall(t *testing.T) {

--- a/pkg/analyzer/testdata/src/examples/regular.go
+++ b/pkg/analyzer/testdata/src/examples/regular.go
@@ -1,0 +1,14 @@
+package examples
+
+type testDummy string
+
+func (td *testDummy) Finish() {}
+
+func New() testDummy {
+	return testDummy("this is a test")
+}
+
+func Finish() {
+	td := New()
+	td.Finish()
+}

--- a/pkg/analyzer/testdata/src/examples/regular.go
+++ b/pkg/analyzer/testdata/src/examples/regular.go
@@ -1,11 +1,11 @@
 package examples
 
-type testDummy string
+type testDummy struct{}
 
 func (td *testDummy) Finish() {}
 
-func New() testDummy {
-	return testDummy("this is a test")
+func New() *testDummy {
+	return &testDummy{}
 }
 
 func Finish() {

--- a/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
@@ -22,6 +22,15 @@ func TestRenamedNoFinishCall(t *testing.T) {
 }
 
 func TestRenamedFinishCallWithoutT(t *testing.T) {
-	mock := gomock.NewController(nil)
-	mock.Finish()
+	mock := gomick.NewController(nil)
+	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+}
+
+func TestRenamedFinsihCallInAnotherFunction(t *testing.T) {
+	mock := gomick.NewController(t)
+	renamedCallFinish(mock)
+}
+
+func renamedCallFinish(mock *gomock.Controller) {
+	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
 }

--- a/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
@@ -17,10 +17,6 @@ func TestRenamedFinishCallDefer(t *testing.T) {
 	defer mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
 }
 
-func TestRenamedNoFinishCall(t *testing.T) {
-	gomick.NewController(t)
-}
-
 func TestRenamedFinishCallWithoutT(t *testing.T) {
 	mock := gomick.NewController(nil)
 	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
@@ -33,4 +29,8 @@ func TestRenamedFinsihCallInAnotherFunction(t *testing.T) {
 
 func renamedCallFinish(mock *gomock.Controller) {
 	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+}
+
+func TestRenamedNoFinishCall(t *testing.T) {
+	gomick.NewController(t)
 }

--- a/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
+++ b/pkg/analyzer/testdata/src/examples/renamed_pkg_test.go
@@ -9,17 +9,17 @@ import (
 
 func TestRenamedFinishCall(t *testing.T) {
 	mock := gomick.NewController(t)
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestRenamedFinishCallDefer(t *testing.T) {
 	mock := gomick.NewController(t)
-	defer mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	defer mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestRenamedFinishCallWithoutT(t *testing.T) {
 	mock := gomick.NewController(nil)
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestRenamedFinsihCallInAnotherFunction(t *testing.T) {
@@ -28,7 +28,7 @@ func TestRenamedFinsihCallInAnotherFunction(t *testing.T) {
 }
 
 func renamedCallFinish(mock *gomock.Controller) {
-	mock.Finish() // want "since go1.14, if you are passing a testing.T to NewController then calling Finish on gomock.Controller is no longer needed"
+	mock.Finish() // want "calling Finish on gomock.Controller is no longer needed"
 }
 
 func TestRenamedNoFinishCall(t *testing.T) {


### PR DESCRIPTION
Simplify linter logic:
- no need to check if `*testing.T` is passed to `NewController` since it's mandatory and `gomock` won't work with it
- add case for unit test