### PR TITLE
Rename linter to gomocklinter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ^1.20
-      - run: cd /tmp && go install github.com/hendrywiranto/gomockcontrollerfinish@${{ env.GITHUB_REF_NAME }} && gomockcontrollerfinish -h
+      - run: cd /tmp && go install github.com/hendrywiranto/gomocklinter@${{ env.GITHUB_REF_NAME }} && gomocklinter -h
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
-# gomockcontrollerfinish
+# gomocklinter
 
-![CI](https://github.com/hendrywiranto/gomockcontrollerfinish/workflows/CI/badge.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hendrywiranto/gomockcontrollerfinish)](https://goreportcard.com/report/github.com/hendrywiranto/gomockcontrollerfinish)
-[![Coverage Status](https://coveralls.io/repos/github/hendrywiranto/gomockcontrollerfinish/badge.svg?branch=main)](https://coveralls.io/github/hendrywiranto/gomockcontrollerfinish?branch=main)
+![CI](https://github.com/hendrywiranto/gomocklinter/workflows/CI/badge.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/hendrywiranto/gomocklinter)](https://goreportcard.com/report/github.com/hendrywiranto/gomocklinter)
+[![Coverage Status](https://coveralls.io/repos/github/hendrywiranto/gomocklinter/badge.svg?branch=main)](https://coveralls.io/github/hendrywiranto/gomocklinter?branch=main)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
-A linter that checks whether an unnecessary call to .Finish() on gomock.Controller exists
+A linter that checks the usage of go mocking libraries
 
-Note: The original [golang/mock](https://github.com/golang/mock) package is archived and the maintained fork is [go.uber.org/mock](https://github.com/uber/mock). This linter supports both.
+Note: The original [golang/mock](https://github.com/golang/mock) package is archived and the maintained fork is [go.uber.org/mock](https://github.com/uber/mock).  
+This linter supports both.
 
 ## Installation & usage
 
 ```
-$ go install github.com/hendrywiranto/gomockcontrollerfinish@latest
-$ gomockcontrollerfinish ./...
+$ go install github.com/hendrywiranto/gomocklinter@latest
+$ gomocklinter ./...
 ```
 
 or build the binary and use `go vet`
 ```
-$ go build -o gomockcontrollerfinish main.go
-$ go vet -vettool=./gomockcontrollerfinish ./...
+$ go build -o gomocklinter main.go
+$ go vet -vettool=./gomocklinter ./...
 ```
 
 ## Motivation

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hendrywiranto/gomockcontrollerfinish
+module github.com/hendrywiranto/gomocklinter
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"golang.org/x/tools/go/analysis/singlechecker"
 
-	"github.com/hendrywiranto/gomockcontrollerfinish/pkg/analyzer"
+	"github.com/hendrywiranto/gomocklinter/pkg/analyzer"
 )
 
 func main() {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -22,11 +22,11 @@ var pkgSourcesMap = map[string]bool{
 	"go.uber.org": true,
 }
 
-// New returns new gomockcontrollerfinish analyzer.
+// New returns new gomocklinter analyzer.
 func New() *analysis.Analyzer {
 	return &analysis.Analyzer{
-		Name:     "gomockcontrollerfinish",
-		Doc:      "Checks whether an unnecessary call to .Finish() on gomock.Controller exists",
+		Name:     "gomocklinter",
+		Doc:      "Checks the usage of go mocking libraries",
 		Run:      run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	}

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -6,10 +6,10 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 
 	"github.com/gostaticanalysis/testutil"
-	"github.com/hendrywiranto/gomockcontrollerfinish/pkg/analyzer"
+	"github.com/hendrywiranto/gomocklinter/pkg/analyzer"
 )
 
-func TestGomockControllerFinish(t *testing.T) {
+func TestGoMockLinter(t *testing.T) {
 	pkgs := []string{
 		"examples",
 	}


### PR DESCRIPTION
This PR renames this linter to `gomocklinter` since it will allow for extendability for more features
Currently only support detection of unnecessary `.Finish()` call to gomock controller